### PR TITLE
Introduce feature serde_lossy that can deserialize u64, i64, f64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = { optional = true, version = "1" }
 
 [features]
 default = ["ord_subset", "rustc-serialize", "serde"]
+serde_lossy = ["serde"]
 
 [build-dependencies]
 gcc = "~0.3"

--- a/README.md
+++ b/README.md
@@ -28,3 +28,19 @@ assert_eq(x + y, z);
 $ cargo build
 $ ./target/debug/run-test decTest/decQuad.decTest
 ```
+# (De)serializing using serde
+
+`d128` supports (de)serialization using serde by default (feature `serde`). d128 is serialized from and to string:
+
+```rust
+    assert_eq!(d128!(5.4321), serde_json::from_str("\"5.4321\"").unwrap());
+    assert_eq!("\"1.2345\"".to_string(), serde_json::to_string(&d128!(1.2345)).unwrap());
+```
+
+If you want to deserialize from numbers, e.g. in json, enable the features `serde` and `serde_lossy`.
+This will make serde _de_serialize integer and floating-point numbers as well.
+
+_Note_: Due to the way serde is designed, using `serde_lossy` to deserialize fractions such as `0.3` can incur in
+*loss of precision*, as the number is deserialized to `f64` first before being converted to `d128`. This is why
+d128 are only ever serialized to Strings. Still, it can make sense to enable `serde_lossy` for an initial import of 
+data that only exists as floating point json; which is from then on treated as d128.

--- a/src/dec128.rs
+++ b/src/dec128.rs
@@ -114,6 +114,29 @@ impl<'de> serde::de::Visitor<'de> for d128Visitor {
         use serde::de::Unexpected;
         d128::from_str(s).map_err(|_| E::invalid_value(Unexpected::Str(s), &self))
     }
+
+    #[cfg(feature = "serde_lossy")]
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where E: serde::de::Error,
+    {
+        Ok(v.into())
+    }
+
+    #[cfg(feature = "serde_lossy")]
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where E: serde::de::Error,
+    {
+        Ok(v.into())
+    }
+
+    #[cfg(feature = "serde_lossy")]
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+        where E: serde::de::Error,
+    {
+        // This seems to be the best way to convert from f64 to str.
+        // We already have a f64 here, so we already lost precision.
+        self.visit_str(format!("{}", v).as_str())
+    }
 }
 
 /// Converts an i32 to d128. The result is exact and no error is possible.
@@ -1022,6 +1045,31 @@ mod tests {
             "{\"amt\":\"9.9\",\"price\":\"432.232\"}");
         let b = from_str("{\"price\":\"432.232\",\"amt\":\"9.9\"}").unwrap();
         assert_eq!(a, b);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_readme() {
+        use ::serde_json;
+        assert_eq!(d128!(5.4321), serde_json::from_str("\"5.4321\"").unwrap());
+        assert_eq!("\"1.2345\"".to_string(), serde_json::to_string(&d128!(1.2345)).unwrap());
+    }
+
+    #[cfg(feature = "serde_lossy")]
+    #[test]
+    fn test_serde_lossy() {
+        let map : BTreeMap<String, d128> = from_str(r###"{
+            "negative_number": -1,
+            "positive_number": 3,
+            "large_positive_number": 5000000000,
+            "half": 0.5,
+            "fifth": 0.2
+        }"###).expect("Expected parsable json");
+        assert_eq!(Some(&d128!(-1)), map.get("negative_number"));
+        assert_eq!(Some(&d128!(3)), map.get("positive_number"));
+        assert_eq!(Some(&d128!(5000000000)), map.get("large_positive_number"));
+        assert_eq!(Some(&d128!(0.5)), map.get("half"));
+        assert_eq!(Some(&d128!(0.2)), map.get("fifth"));
     }
 
     #[test]


### PR DESCRIPTION
The goal is to be able to deserialize json like {a: 1, b: 2.5} into {a: d128, b: d128} using serde.

I think something "opt-in" is needed, at least for floating point, because serde will parse "numbers with comma" as f64, possibly losing precision. (see my changes to Readme.md)

I'm not 100% sure about this approach, but this works and is opt-in.

You can test this using `cargo test --features serde_lossy`.

An alternative approach is to expose an alternative visitor and implement `visit_f64()` etc. for that visitor. That alternative visitor can then be used through [`#[serde(deserialize_with = ...)]`](https://serde.rs/field-attrs.html). However that is much more cumbersome, as you'd need to annotate _every_ field with `#[serde(deserialize_with = ...)]` and I'm not sure how to handle e.g. BTreeMap<String, d128> with that approach.

Let me know what you think. I'm happy to implement different approaches you might prefer.