### PR TITLE
bump ord_subset to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 bitflags = "~0.7"
 libc = "~0.2"
-ord_subset = { optional = true, version = "~1.2" }
+ord_subset = { optional = true, version = "~2.0" }
 rustc-serialize = { optional = true, version = "~0.3" }
 serde = { optional = true, version = "1" }
 


### PR DESCRIPTION
Since `ord_subset` is not exposed by this crate, it is useful to keep it up-to-date since this is the version a user will expect, and mismatched versions gives that annoying `not implemented` error