### PR TITLE
update ord_subset dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ travis-ci = { repository = "alkis/decimal" }
 [dependencies]
 bitflags = "1"
 libc = "0.2"
-ord_subset = { optional = true, version = "2" }
+ord_subset = { optional = true, version = "3" }
 rustc-serialize = { optional = true, version = "0.3" }
 serde = { optional = true, version = "1" }
 


### PR DESCRIPTION
This adds the new unstable_sorts from the std library. Also fixes bug that was disallowing
binary_search on immutable slices.

I'm sorry for the version churn, but so long as I can't stop others from implementing the `*Ext` traits, I have to treat these changes as breaking. Shouldn't affect you since you are only implementing `OrdSubset`, though I couldn't run the tests locally.