### PR TITLE
allow build on aarch64

### DIFF
--- a/src/dec128.rs
+++ b/src/dec128.rs
@@ -224,7 +224,7 @@ impl Into<u32> for d128 {
 /// payload is 0.
 impl fmt::Display for d128 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let mut buf = [0 as i8; 43];
+        let mut buf = [0; 43];
         unsafe {
             decQuadToString(self, buf.as_mut().as_mut_ptr());
             let cstr = CStr::from_ptr(buf.as_ptr());
@@ -244,7 +244,7 @@ impl fmt::Debug for d128 {
 /// exponential notation is used the exponent will be a multiple of 3.
 impl fmt::LowerExp for d128 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let mut buf = [0 as i8; 43];
+        let mut buf = [0; 43];
         unsafe {
             decQuadToEngString(self, buf.as_mut().as_mut_ptr());
             let cstr = CStr::from_ptr(buf.as_ptr());


### PR DESCRIPTION
`i8` is equal to `c_char` on x86, it is different on other platforms. Please use the aliases defined in `libc` or let rust infer the type, as is the case here.