### PR TITLE
Add ::infinity and ::neg_infinity functions

### DIFF
--- a/src/dec128.rs
+++ b/src/dec128.rs
@@ -539,6 +539,16 @@ impl d128 {
         }
     }
 
+    /// Returns the d128 representing +Infinity.
+    pub fn infinity() -> d128 {
+        d128!(Infinity)
+    }
+
+    /// Returns the d128 representing -Infinity.
+    pub fn neg_infinity() -> d128 {
+        d128!(-Infinity)
+    }
+
     // Computational.
 
     /// Returns the absolute value of `self`.
@@ -982,6 +992,14 @@ mod tests {
     fn default() {
         assert_eq!(d128::zero(), d128::default());
         assert_eq!(d128::zero(), Default::default());
+
+        assert!(d128::infinity().is_infinite());
+        assert!(!d128::infinity().is_negative());
+
+        assert!(d128::neg_infinity().is_infinite());
+        assert!(d128::neg_infinity().is_negative());
+
+        assert_eq!(d128::infinity() + d128!(1), d128::infinity());
     }
 
     #[cfg(feature = "ord_subset")]

--- a/src/dec128.rs
+++ b/src/dec128.rs
@@ -992,7 +992,10 @@ mod tests {
     fn default() {
         assert_eq!(d128::zero(), d128::default());
         assert_eq!(d128::zero(), Default::default());
+    }
 
+    #[test]
+    fn special() {
         assert!(d128::infinity().is_infinite());
         assert!(!d128::infinity().is_negative());
 


### PR DESCRIPTION
Once the d128! macro can be evaluated at compile-time, we can add constants too, but for now, this is the easiest way to add some convenience.