### PR TITLE
Adds truncate, half-up rounding functions

### DIFF
--- a/src/dec128.rs
+++ b/src/dec128.rs
@@ -26,6 +26,8 @@ use std::str::FromStr;
 use std::str::from_utf8_unchecked;
 
 thread_local!(static CTX: RefCell<Context> = RefCell::new(d128::default_context()));
+thread_local!(static ROUND_DOWN: RefCell<Context> = RefCell::new(d128::with_rounding(Rounding::Down)));
+thread_local!(static HALF_UP: RefCell<Context> = RefCell::new(d128::with_rounding(Rounding::HalfUp)));
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -494,6 +496,28 @@ impl d128 {
         }
     }
 
+    /// Initialize a `Context` with the specified `Rounding`.
+    fn with_rounding(rounding: Rounding) -> Context {
+        unsafe {
+            let mut res: Context = uninitialized();
+            let mut ctx = *decContextDefault(&mut res, 128);
+            decContextSetRounding(&mut ctx, rounding as u32);
+            ctx
+        }
+    }
+
+    fn with_round_down<F, R>(f: F) -> R
+        where F: FnOnce(&mut Context) -> R
+    {
+        ROUND_DOWN.with(|ctx| f(&mut ctx.borrow_mut()))
+    }
+
+    fn with_half_up<F, R>(f: F) -> R
+        where F: FnOnce(&mut Context) -> R
+    {
+        HALF_UP.with(|ctx| f(&mut ctx.borrow_mut()))
+    }
+
     fn with_context<F, R>(f: F) -> R
         where F: FnOnce(&mut Context) -> R
     {
@@ -694,8 +718,62 @@ impl d128 {
     /// Returns `self` set to have the same quantum as `other`, if possible (that is, numerically
     /// the same value but rounded or padded if necessary to have the same exponent as `other`, for
     /// example to round a monetary quantity to cents).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #[macro_use]
+    /// extern crate decimal;
+    ///
+    /// fn main() {
+    ///     let prec = d128!(0.1);
+    ///     assert_eq!(d128!(0.400012342423).quantize(prec), d128!(0.4));
+    ///     // uses default rounding (half even)
+    ///     assert_eq!(d128!(0.05).quantize(prec), d128!(0.0));
+    ///     assert_eq!(d128!(0.15).quantize(prec), d128!(0.2));
+    /// }
+    /// ```
     pub fn quantize<O: AsRef<d128>>(mut self, other: O) -> d128 {
         d128::with_context(|ctx| unsafe { *decQuadQuantize(&mut self, &self, other.as_ref(), ctx) })
+    }
+
+    /// Like `quantize`, but uses `Rounding::Down`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #[macro_use]
+    /// extern crate decimal;
+    ///
+    /// fn main() {
+    ///     let prec = d128!(0.1);
+    ///     assert_eq!(d128!(0.05).truncate(prec), d128!(0.0));
+    ///     assert_eq!(d128!(0.15).truncate(prec), d128!(0.1));
+    ///     assert_eq!(d128!(0.19).truncate(prec), d128!(0.1));
+    /// }
+    /// ```
+    pub fn truncate<O: AsRef<d128>>(mut self, other: O) -> d128 {
+        d128::with_round_down(|ctx| unsafe { *decQuadQuantize(&mut self, &self, other.as_ref(), ctx) })
+    }
+
+    /// Like `quantize`, but uses `Rounding::HalfUp`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #[macro_use]
+    /// extern crate decimal;
+    ///
+    /// fn main() {
+    ///     let prec = d128!(0.1);
+    ///     assert_eq!(d128!(0.15).round(prec), d128!(0.2));
+    ///     assert_eq!(d128!(0.14999999999).round(prec), d128!(0.1));
+    ///     assert_eq!(d128!(0.19).round(prec), d128!(0.2));
+    ///     assert_eq!(d128!(0.05).round(prec), d128!(0.1));
+    /// }
+    /// ```
+    pub fn round<O: AsRef<d128>>(mut self, other: O) -> d128 {
+        d128::with_half_up(|ctx| unsafe { *decQuadQuantize(&mut self, &self, other.as_ref(), ctx) })
     }
 
     /// Returns a copy of `self` with its coefficient reduced to its shortest possible form without
@@ -855,6 +933,7 @@ impl d128 {
 extern "C" {
     // Context.
     fn decContextDefault(ctx: *mut Context, kind: uint32_t) -> *mut Context;
+    fn decContextSetRounding(ctx: *mut Context, rounding: uint32_t);
     // Utilities and conversions, extractors, etc.
     fn decQuadFromBCD(res: *mut d128, exp: i32, bcd: *const u8, sign: i32) -> *mut d128;
     fn decQuadFromInt32(res: *mut d128, src: int32_t) -> *mut d128;


### PR DESCRIPTION
This is an alternative approach to allowing the user to specify a mode for a closure, namely, providing two specific and commonly used rounding functions in a `quantize`-like interface.

This commit adds

- A binding to the `decContextSetRounding` function
- A d128 method, `with_rounding` to initialize a `Context` with a given
`Rounding`
- `ROUND_DOWN` and `HALF_UP` thread local static `Context`s initialized
with those roundings
- Two methods on d128, `with_round_down` and `with_half_up` that mimic
`with_context` but use alternative roundings
- Two methods, `truncate` and `round` that offer `quantize` like
interfaces to these rounding settings.