### PR TITLE
Add Readme to crates.io page

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.4"
 authors = ["Alkis Evlogimenos <alkis@evlogimenos.com>"]
 build = "build.rs"
 description = "Decimal floating point arithmetic for Rust"
+readme = "README.md"
 repository = "https://github.com/alkis/decimal"
 documentation = "https://alkis.github.io/decimal"
 keywords = ["decimal", "decNumber"]


### PR DESCRIPTION
Update Cargo.toml to specify the location of the README file. This will let the entire README show up on crates.io, rather than just the one liner description.