### PR TITLE
Fixed #66: equal numbers issue different hashes

### DIFF
--- a/src/dec128.rs
+++ b/src/dec128.rs
@@ -83,7 +83,15 @@ impl Encodable for d128 {
 
 impl Hash for d128 {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.bytes.hash(state);
+        d128::with_context(|ctx| unsafe {
+            let mut num_self: MaybeUninit<decNumber> = MaybeUninit::uninit();
+            decimal128ToNumber(self, num_self.as_mut_ptr());
+            let mut num_self = num_self.assume_init();
+            decNumberTrim(&mut num_self);
+            let mut trimmed_self: d128 = d128::default();
+            decimal128FromNumber(&mut trimmed_self, &num_self, ctx);
+            trimmed_self.bytes.hash(state);
+        });
     }
 }
 
@@ -993,6 +1001,7 @@ extern "C" {
                       rhs: *const decNumber,
                       ctx: *mut Context)
                       -> *mut decNumber;
+    fn decNumberTrim(src: *mut decNumber) -> *mut decNumber;
 }
 
 #[cfg(test)]
@@ -1001,6 +1010,7 @@ mod tests {
     use super::*;
     #[cfg(any(feature = "ord_subset", feature = "serde"))]
     use std::collections::BTreeMap;
+    use std::collections::hash_map::DefaultHasher;
 
     #[cfg(feature = "ord_subset")]
     use ord_subset;
@@ -1145,5 +1155,29 @@ mod tests {
         assert_eq!(d128!(10), decimals.iter().sum());
 
         assert_eq!(d128!(10), decimals.into_iter().sum());
+    }
+
+    #[test]
+    fn test_hash() {
+        let d1 = d128::from_str("0.100").unwrap();
+        let d2 = d128::from_str("0.1").unwrap();
+        assert_eq!(d1, d2);
+        let mut hasher = DefaultHasher::new();
+        d1.hash(&mut hasher);
+        let h1 = hasher.finish();
+        let mut hasher = DefaultHasher::new();
+        d2.hash(&mut hasher);
+        let h2 = hasher.finish();
+        assert_eq!(h1, h2);
+
+        let d1 = d128!(0.123);
+        let d2 = d128!(0.234);
+        let mut hasher = DefaultHasher::new();
+        d1.hash(&mut hasher);
+        let h1 = hasher.finish();
+        let mut hasher = DefaultHasher::new();
+        d2.hash(&mut hasher);
+        let h2 = hasher.finish();
+        assert_ne!(h1, h2);
     }
 }

--- a/src/dec128.rs
+++ b/src/dec128.rs
@@ -83,15 +83,8 @@ impl Encodable for d128 {
 
 impl Hash for d128 {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        d128::with_context(|ctx| unsafe {
-            let mut num_self: MaybeUninit<decNumber> = MaybeUninit::uninit();
-            decimal128ToNumber(self, num_self.as_mut_ptr());
-            let mut num_self = num_self.assume_init();
-            decNumberTrim(&mut num_self);
-            let mut trimmed_self: d128 = d128::default();
-            decimal128FromNumber(&mut trimmed_self, &num_self, ctx);
-            trimmed_self.bytes.hash(state);
-        });
+        let trimmed_self = self.trim();
+        trimmed_self.bytes.hash(state)
     }
 }
 
@@ -745,6 +738,19 @@ impl d128 {
         d128::with_context(|ctx| unsafe { *decQuadScaleB(&mut self, &self, other.as_ref(), ctx) })
     }
 
+    /// Returns self with removed insignificant trailing zeroes.
+    pub fn trim(&self) -> d128 {
+        d128::with_context(|ctx| unsafe {
+            let mut num_self: MaybeUninit<decNumber> = MaybeUninit::uninit();
+            decimal128ToNumber(self, num_self.as_mut_ptr());
+            let mut num_self = num_self.assume_init();
+            decNumberTrim(&mut num_self);
+            let mut trimmed_self: d128 = d128::default();
+            decimal128FromNumber(&mut trimmed_self, &num_self, ctx);
+            trimmed_self
+        })
+    }
+
     // Comparisons.
 
     /// Compares `self` and `other` numerically and returns the result. The result may be –1, 0, 1,
@@ -1155,6 +1161,13 @@ mod tests {
         assert_eq!(d128!(10), decimals.iter().sum());
 
         assert_eq!(d128!(10), decimals.into_iter().sum());
+    }
+
+    #[test]
+    fn test_trim() {
+        let d = d128::from_str("0.100").unwrap();
+        assert_eq!("0.100", d.to_string());
+        assert_eq!("0.1", d.trim().to_string());
     }
 
     #[test]


### PR DESCRIPTION
The idea is to use `decQuadReduce()` function that eliminates insignificant zeroes from the number before hashing.